### PR TITLE
verifier中的mem资源限制

### DIFF
--- a/verifier.cpp
+++ b/verifier.cpp
@@ -138,11 +138,20 @@ void verify_resource(DFG *dfg, const vector<Op*> &ops) {
   int n_mems = dfg->num_memory;
   for (int i = 0; i < n_mems; ++i) {
     vector<tuple<int, int, int>> intv;
-    if (dfg->stmts[i]->is_mem_stmt() && 
-        dfg->stmts[i]->get_arr_idx() == n_mems) {
-      int start = dfg->stmts[i]->start_cycle;
-      int end = start + max(dfg->stmts[i]->op->latency, 1) - 1;
-      intv.push_back({start, end, i});
+    // if (dfg->stmts[i]->is_mem_stmt() && 
+    //     dfg->stmts[i]->get_arr_idx() == n_mems) {
+    //   int start = dfg->stmts[i]->start_cycle;
+    //   int end = start + max(dfg->stmts[i]->op->latency, 1) - 1;
+    //   intv.push_back({start, end, i});
+    // }
+    for(int j = 0; j < n_stmts; ++j){
+      if (dfg->stmts[j]->is_mem_stmt() && dfg->stmts[j]->get_arr_idx() == i) {
+        int start = dfg->stmts[j]->start_cycle;
+        int end = start + max(dfg->stmts[j]->op->latency, 1) - 1;
+        intv.push_back({start, end, j});
+        if(j == 165)
+          cout << dfg->stmts[j]->get_arr_idx() << endl;
+      }
     }
 
     check_intervals("load/store", intv, memport_lim);


### PR DESCRIPTION
按照目前的readme的说明，应该是每一个memory有limit个IO接口（limit为1或者2），那么在检查资源限制的时候没有太看懂原来的逻辑，测试的时候也发现当一个周期内有超过limit个mem指令时，并没有fail。然后修改了逻辑如下，检查每一个mem的资源是否超限